### PR TITLE
Fix CORS configuration to allow frontend requests

### DIFF
--- a/backend/main.go
+++ b/backend/main.go
@@ -56,7 +56,7 @@ func main() {
 	r := gin.Default()
 
 	config := cors.DefaultConfig()
-	config.AllowAllOrigins = true
+	config.AllowOrigins = []string{"https://tango-clone-frontend.onrender.com", "http://localhost:5173"}
 	config.AllowCredentials = true
 	config.AllowMethods = []string{"GET", "POST", "PUT", "DELETE", "OPTIONS"}
 	config.AllowHeaders = []string{"Origin", "Content-Type", "Accept", "Authorization"}


### PR DESCRIPTION
# CORS Configuration Fix

This PR updates the CORS configuration in the backend to explicitly allow requests from the deployed frontend domain:

- Added `https://tango-clone-frontend.onrender.com` to the allowed origins
- Kept `http://localhost:5173` for local development

## Requested by
Ignat Karpov (karpov.ignat@gmail.com)

## Link to Devin run
https://app.devin.ai/sessions/2503d436d0904fbea4bd1142a2d4ab86