### PR TITLE
Fix WebSocket connection to use secure protocol and correct URL format

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -101,7 +101,9 @@ function App() {
   };
 
   const connectWebSocket = (sessionId: string) => {
-    const ws = new WebSocket(`ws://${API_URL.replace('http://', '')}/ws/${sessionId}`);
+    const protocol = API_URL.startsWith('https://') ? 'wss://' : 'ws://';
+    const host = API_URL.replace(/^https?:\/\//, '');
+    const ws = new WebSocket(`${protocol}${host}/ws/${sessionId}`);
 
     ws.onopen = () => {
       console.log('WebSocket connected');


### PR DESCRIPTION
# WebSocket Connection Fix

This PR fixes the WebSocket connection in the frontend to:

- Use secure WSS protocol when connecting to HTTPS backend
- Correctly format the WebSocket URL by properly extracting the host
- Fix the mixed content error when loading over HTTPS

## Requested by
Ignat Karpov (karpov.ignat@gmail.com)

## Link to Devin run
https://app.devin.ai/sessions/2503d436d0904fbea4bd1142a2d4ab86